### PR TITLE
Update PostgreSQL with Extensions to PG18

### DIFF
--- a/PostgreSQL/Extensions/Dockerfile
+++ b/PostgreSQL/Extensions/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:17 AS build
+FROM postgres:18 AS build
 
 WORKDIR /tmp
 
@@ -6,6 +6,6 @@ RUN apt-get update
 
 RUN apt-get install -y --no-install-recommends ca-certificates wget
 
-RUN wget https://github.com/pksunkara/pgx_ulid/releases/download/v0.2.0/pgx_ulid-v0.2.0-pg17-amd64-linux-gnu.deb
+RUN wget https://github.com/pksunkara/pgx_ulid/releases/download/v0.2.1/pgx_ulid-v0.2.1-pg18-amd64-linux-gnu.deb
 
-RUN dpkg -i ./pgx_ulid-v0.2.0-pg17-amd64-linux-gnu.deb
+RUN dpkg -i ./pgx_ulid-v0.2.1-pg18-amd64-linux-gnu.deb

--- a/PostgreSQL/Extensions/README.md
+++ b/PostgreSQL/Extensions/README.md
@@ -4,7 +4,6 @@ This custom dockerfile contains some extensions that might be useful in producti
 
 ## Current extensions
 
-- [ULID](https://github.com/HRKings/pgx_ulid): 128-bit sortable IDs compatible with the existing UUID. ([currently forked for compatibility with PG16](https://github.com/pksunkara/pgx_ulid))
 
 ## Postgres Contrib Modules
 

--- a/PostgreSQL/Extensions/README.md
+++ b/PostgreSQL/Extensions/README.md
@@ -4,6 +4,10 @@ This custom dockerfile contains some extensions that might be useful in producti
 
 ## Current extensions
 
+- [ULID](https://github.com/pksunkara/pgx_ulid): 128-bit sortable IDs compatible with the existing UUID.
+  - **Note:** PostgreSQL 18 introduced UUIDv7, which works basically the same way of an ULID, but respects the format of the traditional UUID, unlike ULID's Crockford's base32 encoding
+  - ULID and UUID can be converted back and forth like so: `SELECT '01K6RVKMF8FV8R5J5GA84GMKKH'::ulid::uuid;` and `SELECT '0199b1b9-d1e8-7ed1-82c8-b052090a4e71'::uuid::ulid;`
+  - I still recommend ULID because I find it easier to read and having a more compact representation. But, that said, UUIDv7 is more widespread and people tend to like more things that are in the standard library of software.
 
 ## Postgres Contrib Modules
 


### PR DESCRIPTION
We now have native UUIDv7! Which works basically the same way of an ULID, but respects the format of the traditional UUID, unlike ULID's Crockford's base32 encoding

ULID and UUID can be converted back and forth like so: 
```sql
SELECT '01K6RVKMF8FV8R5J5GA84GMKKH'::ulid::uuid; 
SELECT '0199b1b9-d1e8-7ed1-82c8-b052090a4e71'::uuid::ulid;
```

I still recommend ULID because I find it easier to read and have a more compact representation.
But, that said, UUIDv7 is more widespread and people tend to like more things that are native.