### PR TITLE
Add two more Graph Databases

### DIFF
--- a/FalkorDB/docker-compose.yaml
+++ b/FalkorDB/docker-compose.yaml
@@ -1,0 +1,10 @@
+services:
+  falkordb:
+    container_name: falkordb
+    image: falkordb/falkordb:latest
+    volumes:
+      - ./falkordb:/data
+    ports:
+      - 6379:6379 # Redis-compatible socket
+      - 3000:3000 # WebUI
+    restart: on-failure

--- a/MemGraph/docker-compose.yaml
+++ b/MemGraph/docker-compose.yaml
@@ -1,0 +1,39 @@
+services:
+  memgraph:
+    image: memgraph/memgraph-mage:latest
+    container_name: memgraph-mage
+    command: ["--log-level=TRACE"]
+    volumes:
+      - mg_lib:/var/lib/memgraph
+      - mg_etc:/etc/memgraph
+    ports:
+      - 7687:7687
+      - 7444:7444
+    restart: on-failure
+
+  lab:
+    image: memgraph/lab:latest
+    container_name: memgraph-lab
+    environment:
+      - QUICK_CONNECT_MG_HOST=memgraph
+      - QUICK_CONNECT_MG_PORT=7687
+    ports:
+      - 3000:3000
+    depends_on:
+      - memgraph
+    restart: on-failure
+
+# We need to create the folders beforehand because of: https://github.com/memgraph/memgraph/issues/1734
+volumes:
+  mg_lib:
+    driver: local
+    driver_opts:
+      type: 'none'
+      o: 'bind'
+      device: './memgraph/data'
+  mg_etc:
+    driver: local
+    driver_opts:
+      type: 'none'
+      o: 'bind'
+      device: './memgraph/config'

--- a/README.md
+++ b/README.md
@@ -5,12 +5,13 @@ This is a place where I gather various templates for Docker to run using Compose
 ## What will you find here?
 
 Application       | Type                 | Description
-------------------|----------------------|-----------------------------------------------------------------------------------------------
+------------------|----------------------|---------------------------------------------------------------------------------------------------------
 Apache Cassandra  | NoSQL Database       | Distributed, wide column store, NoSQL database
 ChartDB           | Tool                 | Database schema diagrams visualizer
 ClickHouse        | OLAP Database        | Database for analytics, observability and data warehousing
 CouchDB           | NoSQL Database       | Document oriented
 CyberChef         | Tool                 | A web app for encryption, encoding, compression and data analysis
+FalkorDB          | Graph Database       | A Graph Database that uses GraphBLAS under the hood for its sparse adjacency matrix graph representation
 Grafana OTeL LGTM | Observability        | OpenTelemetry backend in a Docker image
 InfluxDB          | Time Series Database | Time Series Database Platform Optimized for Speed and Scale
 IT-Tools          | Tool                 | Collection of handy online tools for developers

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Liquibase         | SQL Migration Tool   | Database change management pipelines
 MailPit           | Email                | Email & SMTP testing tool
 MariaDB           | SQL Database         | A community-developed, commercially supported fork of the MySQL
 Meilisearch       | Search Engine        | RESTful search engine API
+MemGraph          | Graph Database       | Memgraph is an open source graph database built for real-time streaming and compatible with Neo4j
 Migrate           | SQL Migration Tool   | Database migrations CLI that uses plain SQL
 MinIO             | Object Storage       | S3 Compatible Storage
 MongoDB           | NoSQL Database       | Document oriented NoSQL database


### PR DESCRIPTION
This PR adds a template for MemGraph and FalkorDB. Alternatives for Neo4j

A note on MemGraph: to be able to use the compose template, you must create the folder where the data will be stored beforehand.